### PR TITLE
Improve performance of cudamemcpy in jetson devices.

### DIFF
--- a/cupoch_conversions/tool/cupoch_conversions_test_node.cu
+++ b/cupoch_conversions/tool/cupoch_conversions_test_node.cu
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     cudaSetDeviceFlags( cudaDeviceScheduleBlockingSync);
 #else
     // use managed memory allocation to speed up memcpy
-    utility::InitializeAllocator(utility::rmmAllocationMode_t::CudaManagedMemoryPool, 1000000000);
+    utility::InitializeAllocator(utility::rmmAllocationMode_t::CudaManagedMemory, 1000000000);
 #endif
 
     private_nh.param("camera3d_point_topic", camera_point_topic, std::string("/points_cloud"));


### PR DESCRIPTION
with this commit 

- reuse stream of cupoch
- attach stream to mem using `cudaStreamAttachMemAsync`

the performance has been improved with the following result.

|   | h2d / h2h time(ms)| stable? |
| ------------- | ------------- |---------|
| pcl |  4ms | stable| 
| CudaDefaultAllocation  | 6-8ms |unstable  |
|PoolAllocation  | 13ms | stable |
|CudaManagedMemory  | 6.8ms | stable |
|CudaManagedMemoryPool  | 13ms | stable |

_Originally posted by @ZhenshengLee in https://github.com/ZhenshengLee/perception_cupoch/issues/9#issuecomment-901923622_

Closes #9 