### PR TITLE
fix issues with spdlog

### DIFF
--- a/cupoch_conversions/CMakeLists.txt
+++ b/cupoch_conversions/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(thrust REQUIRED QUIET)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(urdfdom REQUIRED)
+find_package(CUDA REQUIRED)
 
 message("zs: CUPOCH_INCLUDE_DIRS = " ${CUPOCH_INCLUDE_DIRS})
 message("zs: CUPOCH_LIBRARIES = " ${CUPOCH_LIBRARIES})
@@ -23,61 +24,62 @@ message("zs: EIGEN3_INCLUDE_DIRS = " ${EIGEN3_INCLUDE_DIRS})
 GA_CHECK_CUDA()
 
 include_directories(
-    include
-    ${CUPOCH_INCLUDE_DIRS}
+        include
+        ${CUPOCH_INCLUDE_DIRS}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}/
-)
+        DESTINATION include/${PROJECT_NAME}/
+        )
 
 install(DIRECTORY res
-  DESTINATION lib/${PROJECT_NAME}/
-)
-
-set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "")
+        DESTINATION lib/${PROJECT_NAME}/
+        )
 
 APPEND_TARGET_ARCH_FLAGS()
 
+set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "")
+APPEND_TARGET_ARCH_FLAGS()
 set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
-    ${CUPOCH_NVCC_FLAGS}
-)
+        ${CUPOCH_NVCC_FLAGS}
+        )
 add_definitions(${CUPOCH_DEFINITIONS})
 message("zs: ${CMAKE_PROJECT_NAME} CUDA_NVCC_FLAGS = " ${CUDA_NVCC_FLAGS})
+include(GATest)
 
 # C++ library
 cuda_add_library(cupoch_conversions STATIC src/cupoch_conversions.cu)
 ament_target_dependencies(cupoch_conversions
-    rclcpp
-    sensor_msgs
-    urdfdom
-)
+        rclcpp
+        sensor_msgs
+        urdfdom
+        )
 target_include_directories(cupoch_conversions PRIVATE
-    ${CUPOCH_INCLUDE_DIRS}
-)
+        ${CUPOCH_INCLUDE_DIRS}
+        )
 target_link_directories(cupoch_conversions PRIVATE
-    ${CUPOCH_LIBRARY_DIRS}
-)
+        ${CUPOCH_LIBRARY_DIRS}
+        )
 target_link_libraries(cupoch_conversions
-    ${CUPOCH_LIBRARIES}
-)
+        ${CUPOCH_LIBRARIES}
+        )
 
 # Tests
-if(GA_BUILD_TEST)
+if (GA_BUILD_TEST)
     add_subdirectory(test)
     add_subdirectory(tool)
-endif()
+endif ()
 
 # Install
 install(TARGETS cupoch_conversions
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib/${PROJECT_NAME}
+        )
 
 install(DIRECTORY include/cupoch_conversions/
-    DESTINATION include/${PROJECT_NAME}
-)
+        DESTINATION include/${PROJECT_NAME}
+        )
 
 ament_export_include_directories(include)
 ament_export_libraries(cupoch_conversions)

--- a/cupoch_conversions/cmake/ga_build_common.cmake
+++ b/cupoch_conversions/cmake/ga_build_common.cmake
@@ -2,8 +2,8 @@
 set(GA_BUILD_TEST ON)
 
 # root dirs
-#set(CUPOCH_ROOT $ENV{HOME}/colcon_ws/install/cupoch)
-set(CUPOCH_ROOT "/opt/cupoch/cupoch/")
+set(CUPOCH_ROOT $ENV{HOME}/colcon_ws/install/cupoch)
+#set(CUPOCH_ROOT "/opt/cupoch/cupoch/")
 
 find_package(OpenMP)
 if (OPENMP_FOUND)

--- a/cupoch_conversions/cmake/ga_build_common.cmake
+++ b/cupoch_conversions/cmake/ga_build_common.cmake
@@ -2,6 +2,7 @@
 set(GA_BUILD_TEST ON)
 
 # root dirs
+#set(CUPOCH_ROOT $ENV{HOME}/colcon_ws/install/cupoch)
 set(CUPOCH_ROOT "/opt/cupoch/cupoch/")
 
 find_package(OpenMP)
@@ -52,6 +53,7 @@ set(CUPOCH_INCLUDE_DIRS ${CUPOCH_ROOT}/include
     ${CUPOCH_ROOT}/third_party/fmt/include
     ${CUPOCH_ROOT}/third_party/liblzf/include
     ${CUPOCH_ROOT}/third_party/eigen/
+    ${CUPOCH_ROOT}/third_party/spdlog/include
     ${PNG_INCLUDE_DIRS}
     ${JSONCPP_INCLUDE_DIRS}
 )
@@ -75,6 +77,7 @@ set(CUPOCH_LIBRARIES
     liblzf
     rply
     spdlog
+    ${spdlog_LIBRARIES}
     ${CUDA_LIBRARIES}
     ${CUDA_CUBLAS_LIBRARIES}
     ${CUDA_curand_LIBRARY}


### PR DESCRIPTION
Hi, 
the foxy branch won't build without linking `spdlog`, 

```
1 error detected in the compilation of "/home/atas/colcon_ws/src/perception_cupoch/cupoch_conversions/src/cupoch_conversions.cu".
CMake Error at cupoch_conversions_generated_cupoch_conversions.cu.o.Release.cmake:280 (message):
  Error generating file
  /home/atas/colcon_ws/build/cupoch_conversions/CMakeFiles/cupoch_conversions.dir/src/./cupoch_conversions_generated_cupoch_conversions.cu.o
```

The PR has included linking of `spdlog`

A few humble opinions that might be helpful and improve `cupoch` and its ROS integration;

* `colcon` of ROS2 is actually able to build cupoch inside a workspace(e.g `colcon_ws`), this may not be desirable for some, as cupoch is a large library and takes time to build, but some may find it useful if they are actively modifying/developing code within cupoch, so you don't need to separately build ROS2 packages and cupoch.  

* I have copied the cmake files in `perception_cupoch` and used them to build ROS2 package, 
THank you ! these are very valuable, is there anything to do to simplify these files ? It took me some time to get my head around and build  MWE with `cupoch`, `perception_cupoch` and my own ROS2 code